### PR TITLE
投稿フォームでMarkdown本文を入力・保存できるようにする

### DIFF
--- a/src/features/KnowledgeListFeature.tsx
+++ b/src/features/KnowledgeListFeature.tsx
@@ -12,6 +12,24 @@ export function KnowledgeListFeature({ userId, knowledges }: Props) {
       <p>
         こんにちは <span class="text-blue-500 font-bold">{userId}</span> さん
       </p>
+      <form action="/" method="post">
+        <div class="mb-4">
+          <label class="block text-sm font-medium text-gray-700" for="content">
+            本文
+          </label>
+          <textarea
+            aria-label="ナレッジ本文"
+            class="w-full border border-gray-300 rounded-md p-3 mt-1 bg-white text-sm resize-y min-h-[10rem] focus:outline-none focus:ring-2 focus:ring-blue-300"
+            id="content"
+            name="content"
+            placeholder="Markdownでナレッジを記述してください。例: 見出し、コードブロック、箇条書きなど"
+            rows={8}
+          />
+        </div>
+        <button class="px-4 py-2 bg-blue-500 text-white rounded" type="submit">
+          ナレッジを投稿する
+        </button>
+      </form>
       {knowledges.length ? (
         <ul>
           {knowledges.map((knowledge) => (
@@ -19,9 +37,11 @@ export function KnowledgeListFeature({ userId, knowledges }: Props) {
           ))}
         </ul>
       ) : (
-        <ul>
-          <li>投稿済みのナレッジは 0 件です</li>
-        </ul>
+        <>
+          <ul>
+            <li>投稿済みのナレッジは 0 件です</li>
+          </ul>
+        </>
       )}
     </Layout>
   );

--- a/src/models/knowledge.repository.test.ts
+++ b/src/models/knowledge.repository.test.ts
@@ -1,0 +1,19 @@
+import { rm } from 'node:fs/promises';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { Knowledge } from './knowledge.model.js';
+import { KnowledgeRepository } from './knowledge.repository.js';
+
+describe('KnowledgeRepository', () => {
+  it('保存したナレッジを一覧で取得できる', async () => {
+    const knowledge = Knowledge.create('保存テスト用の内容', 'test-author');
+
+    await KnowledgeRepository.upsert(knowledge);
+
+    const knowledges = await KnowledgeRepository.getAll();
+
+    expect(knowledges.some((item) => item.knowledgeId === knowledge.knowledgeId)).toBe(true);
+
+    await rm(path.join('./storage', `${knowledge.knowledgeId}.json`), { force: true });
+  });
+});

--- a/src/models/knowledge.repository.ts
+++ b/src/models/knowledge.repository.ts
@@ -1,4 +1,5 @@
-import { glob, readFile } from 'node:fs/promises';
+import { glob, mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
 
 import type { Knowledge } from './knowledge.model.js';
 
@@ -10,6 +11,13 @@ async function getAll(): Promise<Knowledge[]> {
   return knowledges;
 }
 
+async function upsert(knowledge: Knowledge): Promise<void> {
+  const filePath = path.join('./storage', `${knowledge.knowledgeId}.json`);
+
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, JSON.stringify(knowledge, null, 2), 'utf-8');
+}
+
 export const KnowledgeRepository = {
   // biome-ignore lint/suspicious/noExplicitAny: TODO: (学生向け) 実装する
   getByKnowledgeId: (_: string): Promise<Knowledge> => undefined as any,
@@ -19,8 +27,7 @@ export const KnowledgeRepository = {
 
   getAll,
 
-  // biome-ignore lint/suspicious/noExplicitAny: TODO: (学生向け) 実装する
-  upsert: (_: Knowledge): Promise<void> => undefined as any,
+  upsert,
 
   // biome-ignore lint/suspicious/noExplicitAny: TODO: (学生向け) 実装する
   deleteByKnowledgeId: (_: string): Promise<void> => undefined as any,

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,5 +1,7 @@
 import { Hono } from 'hono';
 import { getAllKnowledgesController } from './controllers/get-all-knowledges.controller.js';
+import { Knowledge } from './models/knowledge.model.js';
+import { KnowledgeRepository } from './models/knowledge.repository.js';
 
 export interface Variables {
   userId: string;
@@ -14,4 +16,22 @@ router.get('/', (ctx) => {
 
   // MEMO: Controller は Context を直接受け取らず、必要な情報のみを引数に受け取る
   return ctx.html(getAllKnowledgesController(userId));
+});
+
+router.post('/', async (ctx) => {
+  const userId = ctx.get('userId');
+
+  // フォームデータから本文を取得
+  const form = await ctx.req.formData();
+  const content = String(form.get('content') ?? '').trim();
+
+  // 簡易バリデーション: 空ならリダイレクト
+  if (!content) {
+    return ctx.redirect('/');
+  }
+
+  const knowledge = Knowledge.create(content, userId);
+  await KnowledgeRepository.upsert(knowledge);
+
+  return ctx.redirect('/');
 });


### PR DESCRIPTION
## 概要
<!-- PRの背景・目的・概要 -->
概要:

クライアントの投稿フォームにMarkdown本文の入力欄を追加し、サーバ側でフォームデータを受け取って永続化する処理を実装しました。これによりユーザーが任意のMarkdownを投稿できるようになります（表示は未レンダリングのままプレーンテキスト保存）。


## やったこと・やらないこと:

やったこと:
投稿フォームに [textarea](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) を追加（改善：プレースホルダ、フォーカスリング、最小高さ、縦リサイズを許可）。
POST / ハンドラをフォームデータをパースするように変更し、[content](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) を [Knowledge.create](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) → [KnowledgeRepository.upsert](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) に渡して保存するように実装。
ビルド確認（npm run build）済み。
やらないこと（今回意図的に未対応）:
Markdown を HTML に変換して表示する処理（レンダリング／サニタイズ）は未実装。
入力エラーフィードバック（ページ上にエラーメッセージ表示）は簡易実装（空文字時はリダイレクト）に留めている。
[KnowledgeRepository](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) の検索/削除系ユーティリティは別タスク。
影響範囲:

主要変更ファイル:
[KnowledgeListFeature.tsx](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — 投稿フォーム UI を更新
[router.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — POST でフォームを受け取り保存する処理を実装
データ: 投稿は既存の storage/*.json に保存されます（[content](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) フィールドは Markdown テキスト）。
他機能: 一覧表示は現状 ID を表示するのみで、本文のレンダリングや詳細ページは別途実装が必要。
