### PR TITLE
本文を編集を機能を実装

### DIFF
--- a/src/controllers/get-edit-knowledge.controller.tsx
+++ b/src/controllers/get-edit-knowledge.controller.tsx
@@ -1,0 +1,6 @@
+import { EditKnowledgeFeature } from '../features/EditKnowledgeFeature.js';
+import type { Knowledge } from '../models/knowledge.model.js';
+
+export function getEditKnowledgeController(knowledge: Knowledge) {
+  return <EditKnowledgeFeature knowledge={knowledge} />;
+}

--- a/src/features/EditKnowledgeFeature.tsx
+++ b/src/features/EditKnowledgeFeature.tsx
@@ -1,0 +1,36 @@
+import type { Knowledge } from '../models/knowledge.model.js';
+import { Layout } from './Layout.js';
+
+interface Props {
+  knowledge: Knowledge;
+}
+
+export function EditKnowledgeFeature({ knowledge }: Props) {
+  return (
+    <Layout title="ナレッジ編集">
+      <h1 class="text-2xl font-bold mb-4">ナレッジを編集</h1>
+      <form action="/edit" method="post">
+        <input name="knowledgeId" type="hidden" value={knowledge.knowledgeId} />
+
+        <div class="mb-4">
+          <label class="block text-sm font-medium text-gray-700" for="content">
+            本文
+          </label>
+          <textarea
+            aria-label="編集するナレッジ本文"
+            class="w-full border border-gray-300 rounded-md p-3 mt-1 bg-white text-sm resize-y min-h-[10rem] focus:outline-none focus:ring-2 focus:ring-blue-300"
+            id="content"
+            name="content"
+            rows={12}
+          >
+            {knowledge.content}
+          </textarea>
+        </div>
+
+        <button class="px-4 py-2 bg-blue-500 text-white rounded" type="submit">
+          保存する
+        </button>
+      </form>
+    </Layout>
+  );
+}

--- a/src/features/KnowledgeListFeature.tsx
+++ b/src/features/KnowledgeListFeature.tsx
@@ -30,6 +30,24 @@ export function KnowledgeListFeature({ userId, knowledges }: Props) {
           ナレッジを投稿する
         </button>
       </form>
+      <section class="mt-8 p-4 border border-gray-200 rounded-md bg-slate-50">
+        <p class="text-sm text-gray-600 mb-4">編集したいナレッジの ID を入力して、編集ページに移動してください。</p>
+        <form action="/edit" class="flex flex-col gap-3" method="get">
+          <input
+            aria-label="編集する knowledgeId"
+            class="w-full border border-gray-300 rounded-md px-4 py-3 bg-white text-base focus:outline-none focus:ring-2 focus:ring-yellow-300"
+            name="knowledgeId"
+            placeholder="編集したいナレッジの ID を入力"
+            type="text"
+          />
+          <button
+            class="w-full px-5 py-3 bg-yellow-500 text-white font-semibold rounded-lg hover:bg-yellow-600 transition-colors duration-150"
+            type="submit"
+          >
+            ナレッジを編集する
+          </button>
+        </form>
+      </section>
       {knowledges.length ? (
         <ul>
           {knowledges.map((knowledge) => (
@@ -37,11 +55,9 @@ export function KnowledgeListFeature({ userId, knowledges }: Props) {
           ))}
         </ul>
       ) : (
-        <>
-          <ul>
-            <li>投稿済みのナレッジは 0 件です</li>
-          </ul>
-        </>
+        <ul>
+          <li>投稿済みのナレッジは 0 件です</li>
+        </ul>
       )}
     </Layout>
   );

--- a/src/models/knowledge.repository.ts
+++ b/src/models/knowledge.repository.ts
@@ -1,4 +1,4 @@
-import { glob, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { glob, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import type { Knowledge } from './knowledge.model.js';
@@ -11,6 +11,25 @@ async function getAll(): Promise<Knowledge[]> {
   return knowledges;
 }
 
+async function getByKnowledgeId(knowledgeId: string): Promise<Knowledge> {
+  const filePath = path.join('./storage', `${knowledgeId}.json`);
+  const fileContent = await readFile(filePath, 'utf-8');
+
+  return JSON.parse(fileContent) as Knowledge;
+}
+
+async function getByAuthorId(authorId: string): Promise<Knowledge[]> {
+  const knowledges = await getAll();
+
+  return knowledges.filter((knowledge) => knowledge.authorId === authorId);
+}
+
+async function deleteByKnowledgeId(knowledgeId: string): Promise<void> {
+  const filePath = path.join('./storage', `${knowledgeId}.json`);
+
+  await rm(filePath, { force: true });
+}
+
 async function upsert(knowledge: Knowledge): Promise<void> {
   const filePath = path.join('./storage', `${knowledge.knowledgeId}.json`);
 
@@ -19,16 +38,9 @@ async function upsert(knowledge: Knowledge): Promise<void> {
 }
 
 export const KnowledgeRepository = {
-  // biome-ignore lint/suspicious/noExplicitAny: TODO: (学生向け) 実装する
-  getByKnowledgeId: (_: string): Promise<Knowledge> => undefined as any,
-
-  // biome-ignore lint/suspicious/noExplicitAny: TODO: (学生向け) 実装する
-  getByAuthorId: (_: string): Promise<Knowledge[]> => undefined as any,
-
+  getByKnowledgeId,
+  getByAuthorId,
   getAll,
-
   upsert,
-
-  // biome-ignore lint/suspicious/noExplicitAny: TODO: (学生向け) 実装する
-  deleteByKnowledgeId: (_: string): Promise<void> => undefined as any,
+  deleteByKnowledgeId,
 };

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import { getAllKnowledgesController } from './controllers/get-all-knowledges.controller.js';
+import { getEditKnowledgeController } from './controllers/get-edit-knowledge.controller.js';
 import { Knowledge } from './models/knowledge.model.js';
 import { KnowledgeRepository } from './models/knowledge.repository.js';
 
@@ -16,6 +17,53 @@ router.get('/', (ctx) => {
 
   // MEMO: Controller は Context を直接受け取らず、必要な情報のみを引数に受け取る
   return ctx.html(getAllKnowledgesController(userId));
+});
+
+router.get('/edit', async (ctx) => {
+  const userId = ctx.get('userId');
+  const knowledgeId = String(ctx.req.query('knowledgeId') ?? '').trim();
+
+  if (!knowledgeId) {
+    return ctx.redirect('/');
+  }
+
+  try {
+    const knowledge = await KnowledgeRepository.getByKnowledgeId(knowledgeId);
+
+    if (knowledge.authorId !== userId) {
+      return ctx.text('Forbidden', 403);
+    }
+
+    return ctx.html(getEditKnowledgeController(knowledge));
+  } catch {
+    return ctx.redirect('/');
+  }
+});
+
+router.post('/edit', async (ctx) => {
+  const userId = ctx.get('userId');
+  const form = await ctx.req.formData();
+  const knowledgeId = String(form.get('knowledgeId') ?? '').trim();
+  const content = String(form.get('content') ?? '').trim();
+
+  if (!knowledgeId || !content) {
+    return ctx.redirect('/');
+  }
+
+  try {
+    const knowledge = await KnowledgeRepository.getByKnowledgeId(knowledgeId);
+
+    if (knowledge.authorId !== userId) {
+      return ctx.text('Forbidden', 403);
+    }
+
+    const updated = Knowledge.update(knowledge, content);
+    await KnowledgeRepository.upsert(updated);
+
+    return ctx.redirect('/');
+  } catch {
+    return ctx.redirect('/');
+  }
 });
 
 router.post('/', async (ctx) => {


### PR DESCRIPTION
# 概要

ナレッジの本文を編集できる機能を追加しました。

- `GET /edit?knowledgeId=...` で編集画面を表示
- `POST /edit` で既存ナレッジの本文を更新
- 編集権限はログイン中の `userId` と `knowledge.authorId` を比較して判定

# やったこと・やらないこと

## やったこと

- `get-edit-knowledge.controller.tsx` を追加
- `EditKnowledgeFeature.tsx` で編集フォームを実装
- `router.ts` に `/edit` の `GET` / `POST` ルートを追加
- 編集時に `knowledgeId` と `content` の入力チェックを追加
- 自分以外のユーザーのナレッジを編集しようとした場合は `Forbidden` を返すようにした

## やらないこと

- 文字数制限や詳細な入力バリデーションは未実装
- フロント側のリアルタイム検証や JavaScript 補助は未実装

# 影響範囲

## 影響する画面

- ナレッジ編集画面
- ナレッジ一覧画面から編集画面への遷移

## 影響する機能

- 既存ナレッジの更新処理
- 編集権限チェック

※ 既存の新規登録や一覧表示機能には影響しない想定です。

# テスト

- 編集画面にアクセスし、本文を変更して保存できることを確認
- 正しい `knowledgeId` と `content` で更新が反映されることを確認
- 自分以外の `authorId` のナレッジにアクセスした場合は `Forbidden` が返ることを確認

# 変更前 / 変更後

| 変更前 | 変更後 |
|--------|--------|
| <img width="452" height="396" alt="Image20260720143549" src="https://github.com/user-attachments/assets/8619f533-6669-4bf3-8c1a-530e4896fca3" /> | <img width="329" height="311" alt="スクリーンショット 2026-07-20 144338" src="https://github.com/user-attachments/assets/e635102d-ff9f-4667-a7c8-045ed206d8f5" />
 |

## 編集画面
| author ID不一致| author ID一致 |
|--------|--------|
| <img width="272" height="323" alt="スクリーンショット 2026-07-20 144654" src="https://github.com/user-attachments/assets/b9704ad2-dfde-4fe2-953a-464269c44483" /> | <img width="221" height="276" alt="スクリーンショット 2026-07-20 144751" src="https://github.com/user-attachments/assets/84412db6-68f9-42ea-b4be-9a0699bdc4f6" /> |

